### PR TITLE
Fix encoding of crypto outputs

### DIFF
--- a/common/src/crypto.ts
+++ b/common/src/crypto.ts
@@ -24,7 +24,20 @@ const encryptAlgo = {
 
 const format = "jwk";
 
-const stringToUIntArray = (str: string) => new TextEncoder().encode(str);
+export const stringEncode = (str: string): ArrayBuffer =>
+  new TextEncoder().encode(str).buffer;
+
+export const stringDecode = (arr: ArrayBuffer): string =>
+  new TextDecoder().decode(arr);
+
+export const stringFromArrayBuffer = (buf: ArrayBuffer): string =>
+  Array.from(new Uint8Array(buf))
+    .map((n) => String.fromCharCode(n))
+    .join("");
+
+export const arrayBufferFromString = (str: string): ArrayBuffer =>
+  new Uint8Array(Array.from(str).map((c) => c.charCodeAt(0)));
+
 const exportJWK = (key: CryptoKey) => crypto.subtle.exportKey(format, key);
 
 export const genKeyPair = async () => {
@@ -55,9 +68,9 @@ export const encrypt = async (data: string, { encryption }: PublicKey) =>
       await crypto.subtle.importKey(format, encryption, encryptAlgo, true, [
         "encrypt",
       ]),
-      stringToUIntArray(data),
+      stringEncode(data)
     )
-    .then((b) => b.toString());
+    .then(stringFromArrayBuffer);
 
 export const decrypt = async (data: string, { encryption }: PrivateKey) =>
   crypto.subtle
@@ -66,20 +79,20 @@ export const decrypt = async (data: string, { encryption }: PrivateKey) =>
       await crypto.subtle.importKey(format, encryption, encryptAlgo, true, [
         "decrypt",
       ]),
-      stringToUIntArray(data),
+      arrayBufferFromString(data)
     )
-    .then((b) => b.toString());
+    .then(stringDecode);
 
 export const verify = async (
   { signing }: PublicKey,
   signature: Signature,
-  data: string,
+  data: string
 ) =>
   crypto.subtle.verify(
     signAlgo,
     await crypto.subtle.importKey(format, signing, signAlgo, false, ["verify"]),
-    stringToUIntArray(signature),
-    stringToUIntArray(data),
+    arrayBufferFromString(signature),
+    stringEncode(data)
   );
 
 export const sign = async ({ signing }: PrivateKey, data: string) =>
@@ -87,8 +100,8 @@ export const sign = async ({ signing }: PrivateKey, data: string) =>
     .sign(
       signAlgo,
       await crypto.subtle.importKey(format, signing, signAlgo, false, ["sign"]),
-      stringToUIntArray(data),
+      stringEncode(data)
     )
-    .then((b) => b.toString());
+    .then(stringFromArrayBuffer);
 
 export const randomString = () => cryptoRandomString({ length: 64 });


### PR DESCRIPTION
I implemented custom encoding/decoding of crypto outputs - signatures and encrypted blobs.

Tests are passing, but this implementation is not type-safe - `arrayBufferFromString` fails if it gets a string which contains non-ASCII chars.
