### PR TITLE
Refactor crypto

### DIFF
--- a/common/src/crypto.ts
+++ b/common/src/crypto.ts
@@ -1,4 +1,4 @@
-import { Md5 } from "https://deno.land/std@0.119.0/hash/md5.ts";
+import { Sha256 } from "https://deno.land/std@0.119.0/hash/sha256.ts";
 import { cryptoRandomString } from "https://deno.land/x/crypto_random_string@1.0.0/mod.ts";
 
 export type PrivateKey = { signing: JsonWebKey; decryption: JsonWebKey };
@@ -135,11 +135,16 @@ const sortObjKeys = (x: StrObject) =>
       return acc;
     }, {});
 
-const hashJWK = (x: JsonWebKey) =>
-  new Md5().update(JSON.stringify(sortObjKeys(x as StrObject))).toString();
+const hashJWK = (x: JsonWebKey): Sha256 =>
+  new Sha256().update(JSON.stringify(sortObjKeys(x as StrObject)));
 
-export const hashPublicKey = ({ encryption, verification }: PublicKey) =>
-  hashJWK(encryption) + hashJWK(verification);
+export const hashPublicKey = (
+  { encryption, verification }: PublicKey,
+): string =>
+  new Sha256()
+    .update(hashJWK(encryption).arrayBuffer())
+    .update(hashJWK(verification).arrayBuffer())
+    .toString();
 
 export const comparePublicKeys = (p1: PublicKey, p2: PublicKey) =>
   hashPublicKey(p1) === hashPublicKey(p2);

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,2 +1,3 @@
 export * as crypto from "./crypto.ts";
 export * as types from "./types.ts";
+export * as protocol from "./protocol.ts";

--- a/common/src/protocol.test.ts
+++ b/common/src/protocol.test.ts
@@ -3,7 +3,12 @@ import {
   assertEquals,
 } from "https://deno.land/std@0.174.0/testing/asserts.ts";
 
-import { encryptAndSign, verifyAndDecrypt } from "./protocol.ts";
+import {
+  encryptAndSign,
+  MessageNotFromSignerError,
+  SignatureDoesNotMatchError,
+  verifyAndDecrypt,
+} from "./protocol.ts";
 import { genKeyPair, hashPublicKey, sign } from "./crypto.ts";
 
 Deno.test("verify a secure message", async () => {
@@ -65,7 +70,7 @@ Deno.test("attacker fails to spoof a signature", async () => {
   assert(recoveredMessage.isErr);
   assertEquals(
     recoveredMessage.error.reason,
-    "message not from the public key that signed it",
+    MessageNotFromSignerError,
   );
 });
 
@@ -97,6 +102,6 @@ Deno.test("attacker fails to tamper a message", async () => {
   assert(recoveredMessage.isErr);
   assertEquals(
     recoveredMessage.error.reason,
-    "signature doesn't match",
+    SignatureDoesNotMatchError,
   );
 });

--- a/common/src/protocol.test.ts
+++ b/common/src/protocol.test.ts
@@ -1,0 +1,100 @@
+import {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.174.0/testing/asserts.ts";
+
+import { encryptAndSign, verifyAndDecrypt } from "./protocol.ts";
+import { genKeyPair, hashPublicKey, sign } from "./crypto.ts";
+
+Deno.test("verify a secure message", async () => {
+  const testMessage = "A test message!";
+
+  const senderKey = await genKeyPair();
+  const receiverKey = await genKeyPair();
+
+  const getSenderKey = (_: string) => senderKey.publicKey;
+
+  const secureMessage = await encryptAndSign(
+    receiverKey.publicKey,
+    senderKey,
+    testMessage,
+  );
+
+  const recoveredMessage = await verifyAndDecrypt(
+    receiverKey,
+    secureMessage,
+    getSenderKey,
+  );
+
+  assert(recoveredMessage.isOk);
+  assertEquals(recoveredMessage.value.from, senderKey.publicKey);
+  assertEquals(recoveredMessage.value.data, testMessage);
+});
+
+Deno.test("attacker fails to spoof a signature", async () => {
+  const senderKey = await genKeyPair();
+  const receiverKey = await genKeyPair();
+  const attackerKey = await genKeyPair();
+
+  const getAttackerKey = (_: string) => attackerKey.publicKey;
+
+  const authenticMessage = await encryptAndSign(
+    receiverKey.publicKey,
+    senderKey,
+    "A test message!",
+  );
+
+  const spoofedSignature = await sign(
+    attackerKey.privateKey,
+    authenticMessage.cipher,
+  );
+
+  const spoofedMessage = {
+    cipher: authenticMessage.cipher,
+    signature: spoofedSignature,
+    signer: hashPublicKey(attackerKey.publicKey),
+  };
+
+  const recoveredMessage = await verifyAndDecrypt(
+    receiverKey,
+    spoofedMessage,
+    getAttackerKey,
+  );
+
+  assert(recoveredMessage.isErr);
+  assertEquals(
+    recoveredMessage.error.reason,
+    "message wasn't from the pk that signed it",
+  );
+});
+
+Deno.test("attacker fails to tamper a message", async () => {
+  const senderKey = await genKeyPair();
+  const receiverKey = await genKeyPair();
+
+  const getSenderKey = (_: string) => senderKey.publicKey;
+
+  let secureMessage = await encryptAndSign(
+    receiverKey.publicKey,
+    senderKey,
+    "A test message!",
+  );
+
+  const spoofedCipher = "x" + secureMessage.cipher.substring(
+    1,
+    secureMessage.cipher.length,
+  );
+  secureMessage.cipher = spoofedCipher;
+
+  const recoveredMessage = await verifyAndDecrypt(
+    receiverKey,
+    secureMessage,
+    getSenderKey,
+  );
+
+  assert(recoveredMessage.isErr);
+  assertEquals(
+    recoveredMessage.error.reason,
+    "signature doesn't match",
+  );
+});

--- a/common/src/protocol.test.ts
+++ b/common/src/protocol.test.ts
@@ -64,7 +64,7 @@ Deno.test("attacker fails to spoof a signature", async () => {
   assert(recoveredMessage.isErr);
   assertEquals(
     recoveredMessage.error.reason,
-    "message wasn't from the pk that signed it",
+    "message not from the public key that signed it",
   );
 });
 
@@ -74,7 +74,7 @@ Deno.test("attacker fails to tamper a message", async () => {
 
   const getSenderKey = (_: string) => senderKey.publicKey;
 
-  let secureMessage = await encryptAndSign(
+  const secureMessage = await encryptAndSign(
     receiverKey.publicKey,
     senderKey,
     "A test message!",

--- a/common/src/protocol.test.ts
+++ b/common/src/protocol.test.ts
@@ -9,8 +9,9 @@ import { genKeyPair, hashPublicKey, sign } from "./crypto.ts";
 Deno.test("verify a secure message", async () => {
   const testMessage = "A test message!";
 
-  const senderKey = await genKeyPair();
-  const receiverKey = await genKeyPair();
+  const [senderKey, receiverKey] = await Promise.all(
+    [genKeyPair(), genKeyPair()],
+  );
 
   const getSenderKey = (_: string) => senderKey.publicKey;
 
@@ -32,9 +33,9 @@ Deno.test("verify a secure message", async () => {
 });
 
 Deno.test("attacker fails to spoof a signature", async () => {
-  const senderKey = await genKeyPair();
-  const receiverKey = await genKeyPair();
-  const attackerKey = await genKeyPair();
+  const [senderKey, receiverKey, attackerKey] = await Promise.all(
+    [genKeyPair(), genKeyPair(), genKeyPair()],
+  );
 
   const getAttackerKey = (_: string) => attackerKey.publicKey;
 
@@ -69,8 +70,9 @@ Deno.test("attacker fails to spoof a signature", async () => {
 });
 
 Deno.test("attacker fails to tamper a message", async () => {
-  const senderKey = await genKeyPair();
-  const receiverKey = await genKeyPair();
+  const [senderKey, receiverKey] = await Promise.all(
+    [genKeyPair(), genKeyPair()],
+  );
 
   const getSenderKey = (_: string) => senderKey.publicKey;
 

--- a/common/src/protocol.ts
+++ b/common/src/protocol.ts
@@ -1,0 +1,85 @@
+import { err, ok, Result } from "./types.ts";
+
+import {
+  decrypt,
+  encrypt,
+  hashPublicKey,
+  KeyPair,
+  PublicKey,
+  sign,
+  verify,
+} from "./crypto.ts";
+
+export type SecureShortMessage = {
+  cipher: string;
+  signature: string;
+  signer: string;
+};
+
+type PlainTextMessageFormat = {
+  // deno-lint-ignore no-explicit-any
+  data: any;
+  from: string;
+};
+
+export const encryptAndSign = async (
+  you: PublicKey,
+  me: KeyPair,
+  data: string,
+): Promise<SecureShortMessage> => {
+  const myPKHash = hashPublicKey(me.publicKey);
+
+  const message: PlainTextMessageFormat = {
+    from: myPKHash,
+    data,
+  };
+
+  const cipher = await encrypt(JSON.stringify(message), you);
+  const signature = await sign(me.privateKey, cipher);
+
+  return {
+    cipher,
+    signature,
+    signer: myPKHash,
+  };
+};
+
+export type VerifiedMessage = {
+  // deno-lint-ignore no-explicit-any
+  data: any;
+  from: PublicKey;
+};
+
+export type VerificationError =
+  | "signature doesn't match"
+  | "message wasn't from the pk that signed it";
+
+export const verifyAndDecrypt = async (
+  me: KeyPair,
+  message: SecureShortMessage,
+  getPublicKeyFromHash: (arg0: string) => PublicKey,
+): Promise<Result<VerifiedMessage, { reason: VerificationError }>> => {
+  const signer = getPublicKeyFromHash(message.signer);
+  const signatureMatches = await verify(
+    signer,
+    message.signature,
+    message.cipher,
+  );
+  if (!signatureMatches) {
+    return err({ reason: "signature doesn't match" });
+  }
+
+  // TODO: Type checking??
+  const plaintextMessage: PlainTextMessageFormat = JSON.parse(
+    await decrypt(message.cipher, me.privateKey),
+  );
+
+  if (message.signer != plaintextMessage.from) {
+    return err({ reason: "message wasn't from the pk that signed it" });
+  }
+
+  return ok({
+    data: plaintextMessage.data,
+    from: signer,
+  });
+};

--- a/common/src/protocol.ts
+++ b/common/src/protocol.ts
@@ -17,7 +17,7 @@ export type SecureMessage = {
   signer: PublicKey;
 };
 
-type PlainTextMessage = {
+export type PlainTextMessage = {
   data: unknown;
   from: string;
 };
@@ -71,7 +71,7 @@ export const verifyAndDecrypt = async (
   // TODO: Type checking??
   const plaintextMessage: PlainTextMessage = JSON.parse(
     await decryptLongString(me.privateKey, message.cipher),
-  );
+  ) as PlainTextMessage;
 
   if (plaintextMessage.from != hashPublicKey(message.signer)) {
     return err({ reason: MessageNotFromSignerError });

--- a/common/src/protocol.ts
+++ b/common/src/protocol.ts
@@ -52,7 +52,7 @@ export type VerifiedMessage = {
 
 export type VerificationError =
   | "signature doesn't match"
-  | "message wasn't from the pk that signed it";
+  | "message not from the public key that signed it";
 
 export const verifyAndDecrypt = async (
   me: KeyPair,
@@ -75,7 +75,7 @@ export const verifyAndDecrypt = async (
   );
 
   if (message.signer != plaintextMessage.from) {
-    return err({ reason: "message wasn't from the pk that signed it" });
+    return err({ reason: "message not from the public key that signed it" });
   }
 
   return ok({

--- a/common/src/protocol.ts
+++ b/common/src/protocol.ts
@@ -48,9 +48,12 @@ export type VerifiedMessage = {
   from: PublicKey;
 };
 
+export const SignatureDoesNotMatchError = "signature doesn't match";
+export const MessageNotFromSignerError =
+  "message not from the public key that signed it";
 export type VerificationError =
-  | "signature doesn't match"
-  | "message not from the public key that signed it";
+  | typeof SignatureDoesNotMatchError
+  | typeof MessageNotFromSignerError;
 
 export const verifyAndDecrypt = async (
   me: KeyPair,
@@ -64,7 +67,7 @@ export const verifyAndDecrypt = async (
     message.cipher,
   );
   if (!signatureMatches) {
-    return err({ reason: "signature doesn't match" });
+    return err({ reason: SignatureDoesNotMatchError });
   }
 
   // TODO: Type checking??
@@ -73,7 +76,7 @@ export const verifyAndDecrypt = async (
   );
 
   if (message.signer != plaintextMessage.from) {
-    return err({ reason: "message not from the public key that signed it" });
+    return err({ reason: MessageNotFromSignerError });
   }
 
   return ok({

--- a/common/src/protocol.ts
+++ b/common/src/protocol.ts
@@ -16,20 +16,19 @@ export type SecureShortMessage = {
   signer: string;
 };
 
-type PlainTextMessageFormat = {
-  // deno-lint-ignore no-explicit-any
-  data: any;
+type PlainTextMessage = {
+  data: unknown;
   from: string;
 };
 
 export const encryptAndSign = async (
   you: PublicKey,
   me: KeyPair,
-  data: string,
+  data: unknown,
 ): Promise<SecureShortMessage> => {
   const myPKHash = hashPublicKey(me.publicKey);
 
-  const message: PlainTextMessageFormat = {
+  const message: PlainTextMessage = {
     from: myPKHash,
     data,
   };
@@ -45,8 +44,7 @@ export const encryptAndSign = async (
 };
 
 export type VerifiedMessage = {
-  // deno-lint-ignore no-explicit-any
-  data: any;
+  data: unknown;
   from: PublicKey;
 };
 
@@ -70,7 +68,7 @@ export const verifyAndDecrypt = async (
   }
 
   // TODO: Type checking??
-  const plaintextMessage: PlainTextMessageFormat = JSON.parse(
+  const plaintextMessage: PlainTextMessage = JSON.parse(
     await decrypt(message.cipher, me.privateKey),
   );
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,11 +1,7 @@
 export { err, ok, Result } from "npm:true-myth@6.2.0/result";
 
-import {
-  EncryptedShortString,
-  PublicKey,
-  RandomString,
-  Signature,
-} from "./crypto.ts";
+import { PublicKey, RandomString, Signature } from "./crypto.ts";
+import { SecureMessage } from "./protocol.ts";
 
 export interface ServerChallengeMessage {
   type: "challenge";
@@ -33,15 +29,9 @@ export interface NotValidatedMessage {
 // deno-lint-ignore no-explicit-any
 export type ClientMessage = any;
 
-export interface UnderEncryption {
-  from: PublicKey;
-  payload: ClientMessage;
-}
-
 export interface RegularMessagePayload {
-  certificate: Signature;
   to: PublicKey;
-  payload: EncryptedShortString;
+  payload: SecureMessage;
 }
 
 export interface ServerRegularMessage {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,4 +1,11 @@
-import { EncryptedShortString, PublicKey, RandomString, Signature } from "./crypto.ts";
+export { err, ok, Result } from "npm:true-myth@6.2.0/result";
+
+import {
+  EncryptedShortString,
+  PublicKey,
+  RandomString,
+  Signature,
+} from "./crypto.ts";
 
 export interface ServerChallengeMessage {
   type: "challenge";

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,13 +1,19 @@
 import { connect, genKeyPair } from "../../client/src/index.ts";
+import { hashPublicKey } from "../../common/src/crypto.ts";
+import { RegularMessagePayload } from "../../common/src/types.ts";
 
 const { publicKey, privateKey } = await genKeyPair();
 
 connect({
   publicKey,
   privateKey,
-  onMessage: ({ from, payload }) =>
+  onMessage: ({ from, data }) =>
     Promise.resolve(
-      console.log(JSON.stringify(from).slice(0, 10), "says", payload),
+      console.log(
+        hashPublicKey(from).slice(0, 10),
+        "says",
+        (data as RegularMessagePayload).payload,
+      ),
     ),
   onClose: () => {
     console.log("closed socket");


### PR DESCRIPTION
I want to move the secure protocol to its own module, so clients only has to deal with the application layer (acks, etc.).

- [x] Secure short-message (asymmetric API)
- [x] Support both short and long messages
- [ ] Timestamp
- [ ] Replay
- [x] Replace client implementation